### PR TITLE
removed deprecated vendor prefixes for requestAnimationFrame()

### DIFF
--- a/src/utils/fn.js
+++ b/src/utils/fn.js
@@ -126,8 +126,6 @@ export function once(fn, context) {
  */
 export var rAF = (function() {
   return window.requestAnimationFrame
-    || window.webkitRequestAnimationFrame
-    || window.mozRequestAnimationFrame
     || function(callback) {
       window.setTimeout(callback, 1000 / 60)
     }


### PR DESCRIPTION
based on caniuse.com are all browsers (but opera mini) supporting the method without vendor prefixes. I didn't touch the setTimeout fallback for non-supporting browsers (opera mini).